### PR TITLE
Initialise subflows structure at SYN packet

### DIFF
--- a/gtests/net/packetdrill/examples/mptcp/dss/no_mpc_in_3rd_ack_but_mptcp_data_transfer.drill
+++ b/gtests/net/packetdrill/examples/mptcp/dss/no_mpc_in_3rd_ack_but_mptcp_data_transfer.drill
@@ -1,0 +1,18 @@
+0   socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
++0  setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+
++0  bind(3, ..., ...) = 0
++0  listen(3, 1) = 0
+
++0  < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mp_capable a>
++0  > S. 0:0(0) ack 1 win 28800 <mss 1460,nop,nop,sackOK,nop,wscale 6,mp_capable b>
++0  < . 1:1(0) ack 1 win 257
+
++0  accept(3, ..., ...) = 4
+
++0.1 < P. 1:1001(1000) ack 1 win 450 <dss dack4 dsn4 >  sock(4)
++0 > . 1:1(0) ack 1001 <dss dack4> sock(4)
+
++0.1 < P. 1001:2001(1000) ack 1 win 450 <dss dack4 dsn4 >       sock(4)
++0 > . 1:1(0) ack 2001 <dss dack4> sock(4)
+

--- a/gtests/net/packetdrill/examples/mptcp/mp_join/mp_join_packd_to_kernel_backup.pkt
+++ b/gtests/net/packetdrill/examples/mptcp/mp_join/mp_join_packd_to_kernel_backup.pkt
@@ -19,7 +19,7 @@
 
 +0  < S 0:0(0) win 32792 <mss 1000,sackOK,nop,nop,nop,wscale 7,mp_capable key_a> sock(3)
 +0  > S. 0:0(0) ack 1 win 28800 <mss 1460,nop,nop,sackOK,nop,wscale 7,mp_capable key_b> sock(3)
-+0  < . 1:1(0) ack 1 win 257 <mp_capable a b> sock(3)
++0  < . 1:1(0) ack 1 win 257 <mp_capable key_a key_b> sock(3)
 +0  accept(3, ..., ...) = 4
 
 //First subflow

--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -463,6 +463,13 @@ int mptcp_subtype_mp_capable(struct packet *packet_to_modify,
 			!packet_to_modify->tcp->ack){
 		error = mptcp_gen_key();
 		error = mptcp_set_mp_cap_syn_key(tcp_opt_to_modify) || error;
+
+		if(direction == DIRECTION_INBOUND)
+			new_subflow_inbound(packet_to_modify);
+		else if(direction == DIRECTION_OUTBOUND)
+			new_subflow_outbound(live_packet);
+		else
+			return STATUS_ERR;
 	}
 	// Syn and Syn_ack kernel->packetdrill
 	else if(tcp_opt_to_modify->length == TCPOLEN_MP_CAPABLE_SYN &&
@@ -477,13 +484,6 @@ int mptcp_subtype_mp_capable(struct packet *packet_to_modify,
 		// Automatically put the idsn tokens
 		mp_state.idsn = sha1_least_64bits(mp_state.packetdrill_key);
 		mp_state.remote_idsn = sha1_least_64bits(mp_state.kernel_key);
-
-		if(direction == DIRECTION_INBOUND)
-			new_subflow_inbound(packet_to_modify);
-		else if(direction == DIRECTION_OUTBOUND)
-			new_subflow_outbound(live_packet);
-		else
-			return STATUS_ERR;
 	}
 	// SYN_ACK, packetdrill->kernel
 	else if(tcp_opt_to_modify->length == TCPOLEN_MP_CAPABLE_SYN &&

--- a/gtests/net/packetdrill/mptcp.c
+++ b/gtests/net/packetdrill/mptcp.c
@@ -235,7 +235,9 @@ struct mp_subflow *new_subflow_inbound(struct packet *inbound_packet)
 	subflow->packetdrill_rand_nbr =	generate_32();
 	subflow->packetdrill_addr_id = mp_state.last_packetdrill_addr_id;
 	mp_state.last_packetdrill_addr_id++;
-	subflow->ssn = 1; // =1 because it initialized at third ack
+	subflow->ssn = 1; // =1 because the code assumes it is being set with the third ack,
+			  // although that is not the case anymore (new_subflow_inbound is also
+			  // called at syn time)
 //	subflow->state = UNDEFINED;  // TODO to define it and change the state after
 	subflow->next = mp_state.subflows;
 	mp_state.subflows = subflow;


### PR DESCRIPTION
The MPTCP RFC states that the fallback to tcp
should happen only when a data ack with no dss
is encountered, and not at the 3rd ack.

It means that an 3WH of:
- syn with mp_capable
- syn/ack with mp_capable
- ack without mp_capable

should still result in mptcp data transfer if
the dss is correct in subsequent packets.

This patch makes this scenario testable with
packetdrill_mptcp.